### PR TITLE
Fix duplicate declarations

### DIFF
--- a/email.php
+++ b/email.php
@@ -29,7 +29,7 @@ require 'script.php';
 
         $address = $_POST['address'];
 
-        $phone = $_POST['city'];
+        $city = $_POST['city'];
 
         $state = $_POST['state'];
 

--- a/script.php
+++ b/script.php
@@ -4,11 +4,11 @@
     use PHPMailer\PHPMailer\PHPMailer;
     use PHPMailer\PHPMailer\SMTP;
 
-    require 'PHPMailer/src/Exception.php';
-    require 'PHPMailer/src/PHPMailer.php';
-    require 'PHPMailer/src/SMTP.php';
-    require '/usr/share/php/libphp-phpmailer/src/PHPMailer.php';
-    require '/usr/share/php/libphp-phpmailer/src/SMTP.php';
+    require_once 'PHPMailer/src/Exception.php';
+    require_once 'PHPMailer/src/PHPMailer.php';
+    require_once 'PHPMailer/src/SMTP.php';
+    require_once '/usr/share/php/libphp-phpmailer/src/PHPMailer.php';
+    require_once '/usr/share/php/libphp-phpmailer/src/SMTP.php';
 
     require 'config.php';
 


### PR DESCRIPTION
Error: cannot define PHPMailer/PHPMailer/PHPMailer because it already exists in libphp_phpmailer folder. Changed require to require_once.
Also changed typo in php variables in email.php.